### PR TITLE
Optimizations

### DIFF
--- a/cachingController.go
+++ b/cachingController.go
@@ -67,7 +67,7 @@ func (c *healthCheckController) scheduleCheck(mService measuredService, refreshP
 
 	if !c.healthCheckService.isServicePresent(mService.service.name) {
 		infoLogger.Printf("Service with name %s doesn't exist anymore, removing it from cache", mService.service.name)
-		delete(c.measuredServices,mService.service.name)
+		delete(c.measuredServices, mService.service.name)
 		mService.cachedHealth.terminate <- true
 		return
 	}

--- a/cachingController.go
+++ b/cachingController.go
@@ -66,15 +66,16 @@ func (c *healthCheckController) scheduleCheck(mService measuredService, refreshP
 	}
 
 	// run check
-	checkResult := fthealth.RunCheck(mService.service.name,
-		fmt.Sprintf("Checks the health of %v", mService.service.name),
+	serviceToBeChecked :=  mService.service
+	checkResult := fthealth.RunCheck(serviceToBeChecked.name,
+		fmt.Sprintf("Checks the health of %v", serviceToBeChecked.name),
 		true,
-		newServiceHealthCheck(mService.service, c.healthCheckService)).Checks[0]
+		newServiceHealthCheck(serviceToBeChecked, c.healthCheckService)).Checks[0]
 
-	checkResult.Ack = mService.service.ack
+	checkResult.Ack = serviceToBeChecked.ack
 
 	if !checkResult.Ok {
-		severity := c.getSeverityForService(checkResult.Name, mService.service.appPort)
+		severity := c.getSeverityForService(checkResult.Name, serviceToBeChecked.appPort)
 		checkResult.Severity = severity
 	}
 

--- a/checkerService.go
+++ b/checkerService.go
@@ -150,7 +150,7 @@ func (hs *k8sHealthcheckService) getHealthChecksForPod(pod pod, appPort int32) (
 func newPodHealthCheck(pod pod, service service, healthcheckService healthcheckService) fthealth.Check {
 	var checkName string
 	if service.isDaemon {
-		checkName = fmt.Sprintf("%s (%s)",service.name,pod.node)
+		checkName = fmt.Sprintf("%s (%s)", pod.name, pod.node)
 	} else {
 		checkName = pod.name
 	}

--- a/checkerService.go
+++ b/checkerService.go
@@ -150,7 +150,7 @@ func (hs *k8sHealthcheckService) getHealthChecksForPod(pod pod, appPort int32) (
 func newPodHealthCheck(pod pod, service service, healthcheckService healthcheckService) fthealth.Check {
 	var checkName string
 	if service.isDaemon {
-		checkName = fmt.Sprintf("%s-%s",pod.name,pod.node)
+		checkName = fmt.Sprintf("%s-%s",service.name,pod.node)
 	} else {
 		checkName = pod.name
 	}

--- a/checkerService.go
+++ b/checkerService.go
@@ -148,12 +148,19 @@ func (hs *k8sHealthcheckService) getHealthChecksForPod(pod pod, appPort int32) (
 }
 
 func newPodHealthCheck(pod pod, service service, healthcheckService healthcheckService) fthealth.Check {
+	var checkName string
+	if service.isDaemon {
+		checkName = fmt.Sprintf("%s-%s",pod.name,pod.node)
+	} else {
+		checkName = pod.name
+	}
+
 	return fthealth.Check{
 		BusinessImpact:   "On its own this failure does not have a business impact but it represents a degradation of the cluster health.",
-		Name:             pod.name,
+		Name:             checkName,
 		PanicGuide:       "https://sites.google.com/a/ft.com/technology/systems/dynamic-semantic-publishing/coco/runbook",
 		Severity:         defaultSeverity,
-		TechnicalSummary: "The service is not healthy. Please check the panic guide.",
+		TechnicalSummary: "The pod is not healthy. Please check the panic guide.",
 		Checker: func() (string, error) {
 			return "", healthcheckService.checkPodHealth(pod, service.appPort)
 		},

--- a/checkerService.go
+++ b/checkerService.go
@@ -150,7 +150,7 @@ func (hs *k8sHealthcheckService) getHealthChecksForPod(pod pod, appPort int32) (
 func newPodHealthCheck(pod pod, service service, healthcheckService healthcheckService) fthealth.Check {
 	var checkName string
 	if service.isDaemon {
-		checkName = fmt.Sprintf("%s-%s",service.name,pod.node)
+		checkName = fmt.Sprintf("%s (%s)",service.name,pod.node)
 	} else {
 		checkName = pod.name
 	}

--- a/checkerService.go
+++ b/checkerService.go
@@ -35,13 +35,16 @@ func (hs *k8sHealthcheckService) checkServiceHealth(service service) (string, er
 }
 
 func (hs *k8sHealthcheckService) getPodAvailabilityForDeployment(service service) (int32, int32, error) {
-	k8sDeployment, err := hs.k8sClient.ExtensionsV1beta1().Deployments("default").Get(service.name)
-	if err != nil {
+	hs.deployments.RLock()
+	k8sDeployment, ok := hs.deployments.m[service.name]
+	defer hs.deployments.RUnlock()
+
+	if !ok {
 		return 0, 0, fmt.Errorf("Error retrieving deployment with name %s", service.name)
 	}
 
-	noOfUnavailablePods := k8sDeployment.Status.UnavailableReplicas
-	noOfAvailablePods := k8sDeployment.Status.AvailableReplicas
+	noOfUnavailablePods := k8sDeployment.numberOfUnavailableReplicas
+	noOfAvailablePods := k8sDeployment.numberOfAvailableReplicas
 
 	return noOfAvailablePods, noOfUnavailablePods, nil
 }

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,6 @@ dependencies:
     - go get -u github.com/kardianos/govendor
   override:
     - cd $GO_PROJECT_PATH && govendor sync
-    - cd $GO_PROJECT_PATH && go get -t -d -v ./...
     - cd $GO_PROJECT_PATH && go build -v
 
 test:

--- a/controller.go
+++ b/controller.go
@@ -13,12 +13,6 @@ type healthCheckController struct {
 	measuredServices   map[string]measuredService
 }
 
-type measuredService struct {
-	service         service
-	cachedHealth    *cachedHealth
-	bufferedHealths *bufferedHealths
-}
-
 type controller interface {
 	buildServicesHealthResult([]string, bool) (fthealth.HealthResult, map[string]category, map[string]category, error)
 	runServiceChecksByServiceNames([]service, map[string]category) []fthealth.CheckResult

--- a/controller.go
+++ b/controller.go
@@ -125,7 +125,7 @@ func (c *healthCheckController) runServiceChecksByServiceNames(services map[stri
 
 	for i, individualHealthcheck := range healthChecks {
 		if !individualHealthcheck.Ok {
-			unhealthyService, ok := services[individualHealthcheck.Name];
+			unhealthyService, ok := services[individualHealthcheck.Name]
 			if ok {
 				severity := c.getSeverityForService(individualHealthcheck.Name, unhealthyService.appPort)
 				healthChecks[i].Severity = severity

--- a/controller.go
+++ b/controller.go
@@ -156,7 +156,7 @@ func (c *healthCheckController) runServiceChecksFor(categories map[string]catego
 		if category.isSticky && category.isEnabled {
 			for _, serviceName := range category.services {
 				for _, healthCheck := range healthChecks {
-					if healthCheck.Name == serviceName {
+					if healthCheck.Name == serviceName && !healthCheck.Ok {
 						infoLogger.Printf("Sticky category [%s] is unhealthy, disabling it.", category.name)
 						category.isEnabled = false
 						categories[catIndex] = category

--- a/controller_test.go
+++ b/controller_test.go
@@ -2,27 +2,27 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"
 	"testing"
 	"time"
-	"fmt"
 )
 
 const (
-	nonExistingServiceName = "non-existing-service"
-	serviceNameForAckErr = "serviceNameWithAckError"
-	invalidNameForService = "invalidNameForService"
-	nonExistingPodName = "nonExistingPodName"
+	nonExistingServiceName  = "non-existing-service"
+	serviceNameForAckErr    = "serviceNameWithAckError"
+	invalidNameForService   = "invalidNameForService"
+	nonExistingPodName      = "nonExistingPodName"
 	podWithCriticalSeverity = "podWithCriticalSeverity"
-	failingPod = "failingPod"
-	podWithBrokenService = "podWithBrokenService"
+	failingPod              = "failingPod"
+	podWithBrokenService    = "podWithBrokenService"
 	nonExistingCategoryName = "nonExistingCategoryName"
-	validCat = "validCat"
-	validService = "validService"
-	validEnvName="valid-env-name"
+	validCat                = "validCat"
+	validService            = "validService"
+	validEnvName            = "valid-env-name"
 )
 
 type MockService struct {
@@ -60,8 +60,8 @@ func (m *MockService) isServicePresent(serviceName string) bool {
 }
 
 func (m *MockService) getServiceByName(serviceName string) (service, error) {
-	if(serviceName == nonExistingServiceName) {
-		return service{},fmt.Errorf("Cannot find service with name %s",serviceName)
+	if serviceName == nonExistingServiceName {
+		return service{}, fmt.Errorf("Cannot find service with name %s", serviceName)
 	}
 
 	return service{
@@ -397,7 +397,6 @@ func TestRunServiceChecksForStickyCategoryUpdateError(t *testing.T) {
 	assert.False(t, categories["test"].isEnabled)
 }
 
-
 func TestGetMatchingCategoriesHappyFlow(t *testing.T) {
 	categories := make(map[string]category)
 	categories["publishing"] = category{
@@ -421,9 +420,8 @@ func TestGetFinalResultCategoryDisabled(t *testing.T) {
 
 	checkResults := []fthealth.CheckResult{
 		{
-			Ok:false,
-			Severity:1,
-
+			Ok:       false,
+			Severity: 1,
 		},
 	}
 
@@ -434,10 +432,10 @@ func TestGetFinalResultCategoryDisabled(t *testing.T) {
 
 func TestGetEnvironment(t *testing.T) {
 	healthCheckController := &healthCheckController{
-		environment:validEnvName,
+		environment: validEnvName,
 	}
 
 	env := healthCheckController.getEnvironment()
 
-	assert.Equal(t,validEnvName,env)
+	assert.Equal(t, validEnvName, env)
 }

--- a/controller_test.go
+++ b/controller_test.go
@@ -22,6 +22,7 @@ const (
 	nonExistingCategoryName = "nonExistingCategoryName"
 	validCat = "validCat"
 	validService = "validService"
+	validEnvName="valid-env-name"
 )
 
 type MockService struct {
@@ -373,6 +374,30 @@ func TestRunServiceChecksForStickyCategory(t *testing.T) {
 	assert.False(t, categories["test"].isEnabled)
 }
 
+func TestRunServiceChecksForStickyCategoryUpdateError(t *testing.T) {
+	categories := make(map[string]category)
+	categories["publishing"] = category{
+		services: []string{"test-service-name"},
+	}
+
+	categories[nonExistingCategoryName] = category{
+		services:  []string{"test-service-name"},
+		isSticky:  true,
+		isEnabled: true,
+	}
+	categories["test"] = category{
+		services:  []string{"test-service-name"},
+		isSticky:  true,
+		isEnabled: true,
+	}
+
+	controller := initializeMockController("test", nil)
+	checkResult, _ := controller.runServiceChecksFor(categories)
+	assert.NotNil(t, checkResult)
+	assert.False(t, categories["test"].isEnabled)
+}
+
+
 func TestGetMatchingCategoriesHappyFlow(t *testing.T) {
 	categories := make(map[string]category)
 	categories["publishing"] = category{
@@ -394,7 +419,25 @@ func TestGetFinalResultCategoryDisabled(t *testing.T) {
 		isEnabled: false,
 	}
 
-	finalOk, _ := getFinalResult([]fthealth.CheckResult{}, categories)
+	checkResults := []fthealth.CheckResult{
+		{
+			Ok:false,
+			Severity:1,
+
+		},
+	}
+
+	finalOk, _ := getFinalResult(checkResults, categories)
 
 	assert.False(t, finalOk)
+}
+
+func TestGetEnvironment(t *testing.T) {
+	healthCheckController := &healthCheckController{
+		environment:validEnvName,
+	}
+
+	env := healthCheckController.getEnvironment()
+
+	assert.Equal(t,validEnvName,env)
 }

--- a/controller_test.go
+++ b/controller_test.go
@@ -8,19 +8,20 @@ import (
 	"os"
 	"testing"
 	"time"
+	"fmt"
 )
 
 const (
-	nonExistingServiceName  = "non-existing-service"
-	serviceNameForAckErr    = "serviceNameWithAckError"
-	invalidNameForService   = "invalidNameForService"
-	nonExistingPodName      = "nonExistingPodName"
+	nonExistingServiceName = "non-existing-service"
+	serviceNameForAckErr = "serviceNameWithAckError"
+	invalidNameForService = "invalidNameForService"
+	nonExistingPodName = "nonExistingPodName"
 	podWithCriticalSeverity = "podWithCriticalSeverity"
-	failingPod              = "failingPod"
-	podWithBrokenService    = "podWithBrokenService"
+	failingPod = "failingPod"
+	podWithBrokenService = "podWithBrokenService"
 	nonExistingCategoryName = "nonExistingCategoryName"
-	validCat                = "validCat"
-	validService            = "validService"
+	validCat = "validCat"
+	validService = "validService"
 )
 
 type MockService struct {
@@ -48,19 +49,38 @@ func (m *MockService) updateCategory(categoryName string, isEnabled bool) error 
 
 	return nil
 }
-func (m *MockService) getServicesByNames(serviceNames []string) []service {
-	if len(serviceNames) != 0 && serviceNames[0] == nonExistingServiceName {
-		return []service{}
+
+func (m *MockService) isServicePresent(serviceName string) bool {
+	if serviceName == nonExistingServiceName {
+		return false
 	}
 
-	services := []service{
-		{
-			name: "test-service-name",
-			ack:  "test ack",
-		},
-		{
-			name: "test-service-name-2",
-		},
+	return true
+}
+
+func (m *MockService) getServiceByName(serviceName string) (service, error) {
+	if(serviceName == nonExistingServiceName) {
+		return service{},fmt.Errorf("Cannot find service with name %s",serviceName)
+	}
+
+	return service{
+		name: "test-service-name",
+		ack:  "test ack",
+	}, nil
+}
+
+func (m *MockService) getServicesMapByNames(serviceNames []string) map[string]service {
+	if len(serviceNames) != 0 && serviceNames[0] == nonExistingServiceName {
+		return map[string]service{}
+	}
+
+	services := make(map[string]service)
+	services["test-service-name"] = service{
+		name: "test-service-name",
+		ack:  "test ack",
+	}
+	services["test-service-name-2"] = service{
+		name: "test-service-name-2",
 	}
 
 	return services

--- a/handler.go
+++ b/handler.go
@@ -430,12 +430,12 @@ func populateIndividualPodChecks(checks []fthealth.CheckResult, pathPrefix strin
 		if check.Ack != "" {
 			ackCount++
 		}
-
+		podName := extractPodName(check.Name)
 		hc := IndividualHealthcheckParams{
 			Name:         check.Name,
 			Status:       getServiceStatusFromCheck(check),
 			LastUpdated:  check.LastUpdated.Format(timeLayout),
-			MoreInfoPath: fmt.Sprintf("%s/__pod-individual-health?pod-name=%s", pathPrefix, check.Name),
+			MoreInfoPath: fmt.Sprintf("%s/__pod-individual-health?pod-name=%s", pathPrefix, podName),
 			AckMessage:   check.Ack,
 			Output:       check.Output,
 		}
@@ -444,6 +444,16 @@ func populateIndividualPodChecks(checks []fthealth.CheckResult, pathPrefix strin
 	}
 
 	return indiviualServiceChecks, ackCount
+}
+
+func extractPodName(checkName string) string {
+	s := strings.Split(checkName,"")
+
+	if len(s)>=1 {
+		return s[0]
+	}
+
+	return ""
 }
 
 func populateAggregatePodChecks(healthResult fthealth.HealthResult, environment string, serviceName string, pathPrefix string) *AggregateHealthcheckParams {

--- a/handler.go
+++ b/handler.go
@@ -447,9 +447,9 @@ func populateIndividualPodChecks(checks []fthealth.CheckResult, pathPrefix strin
 }
 
 func extractPodName(checkName string) string {
-	s := strings.Split(checkName,"")
+	s := strings.Split(checkName, " ")
 
-	if len(s)>=1 {
+	if len(s) >= 1 {
 		return s[0]
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -206,7 +206,7 @@ func (h *httpHandler) handlePodsHealthCheck(w http.ResponseWriter, r *http.Reque
 
 	healthResult, err := h.controller.buildPodsHealthResult(serviceName)
 
-	infoLogger.Printf("Checking pods health for service [%s], useCache: %t", serviceName, useCache)
+	infoLogger.Printf("Checking pods health for service [%s]", serviceName)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		errorLogger.Printf("Cannot perform checks for service with name %s, error was: %v", serviceName, err.Error())

--- a/handler_test.go
+++ b/handler_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
-	"github.com/golang/go/src/pkg/errors"
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"

--- a/handler_test.go
+++ b/handler_test.go
@@ -77,7 +77,7 @@ func (m *mockController) getMeasuredServices() map[string]measuredService {
 	return map[string]measuredService{}
 }
 
-func (m *mockController) runServiceChecksByServiceNames([]service, map[string]category) []fthealth.CheckResult {
+func (m *mockController) runServiceChecksByServiceNames(map[string]service, map[string]category) []fthealth.CheckResult {
 	return []fthealth.CheckResult{}
 }
 
@@ -121,7 +121,7 @@ func (m *mockController) collectChecksFromCachesFor(map[string]category) ([]fthe
 	return []fthealth.CheckResult{}, map[string][]fthealth.CheckResult{}
 }
 
-func (m *mockController) updateCachedHealth([]service, map[string]category) {
+func (m *mockController) updateCachedHealth(map[string]service, map[string]category) {
 
 }
 

--- a/model.go
+++ b/model.go
@@ -11,14 +11,6 @@ type pod struct {
 	serviceName string
 }
 
-type service struct {
-	name        string
-	ack         string
-	appPort     int32
-	isResilient bool
-	isDaemon    bool
-}
-
 type category struct {
 	name          string
 	services      []string
@@ -35,6 +27,19 @@ type deployment struct {
 type deploymentsMap struct {
 	sync.RWMutex
 	m map[string]deployment
+}
+
+type service struct {
+	name        string
+	ack         string
+	appPort     int32
+	isResilient bool
+	isDaemon    bool
+}
+
+type servicesMap struct {
+	sync.RWMutex
+	m map[string]service
 }
 
 type measuredService struct {

--- a/model.go
+++ b/model.go
@@ -7,6 +7,7 @@ import (
 
 type pod struct {
 	name        string
+	node        string
 	ip          string
 	serviceName string
 }

--- a/model.go
+++ b/model.go
@@ -28,8 +28,8 @@ type category struct {
 }
 
 type deployment struct {
-	numberOfAvailableReplicas   int
-	numberOfUnavailableReplicas int
+	numberOfAvailableReplicas   int32
+	numberOfUnavailableReplicas int32
 }
 
 type deploymentsMap struct {

--- a/model.go
+++ b/model.go
@@ -1,6 +1,9 @@
 package main
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 type pod struct {
 	name        string
@@ -22,4 +25,14 @@ type category struct {
 	refreshPeriod time.Duration
 	isSticky      bool
 	isEnabled     bool
+}
+
+type deployment struct {
+	numberOfAvailableReplicas   int
+	numberOfUnavailableReplicas int
+}
+
+type deploymentsMap struct {
+	sync.RWMutex
+	m map[string]deployment
 }

--- a/model.go
+++ b/model.go
@@ -36,3 +36,9 @@ type deploymentsMap struct {
 	sync.RWMutex
 	m map[string]deployment
 }
+
+type measuredService struct {
+	service         service
+	cachedHealth    *cachedHealth
+	bufferedHealths *bufferedHealths
+}

--- a/service.go
+++ b/service.go
@@ -288,7 +288,7 @@ func (hs *k8sHealthcheckService) getServiceByName(serviceName string) (service, 
 	defer hs.services.RUnlock()
 
 	if service, ok := hs.services.m[serviceName]; ok {
-		return service,nil
+		return service, nil
 	}
 
 	return service{}, fmt.Errorf("Cannot find service with name %s", serviceName)
@@ -384,6 +384,7 @@ func populateCategory(k8sCatData map[string]string) category {
 func populatePod(k8sPod v1.Pod) pod {
 	return pod{
 		name:        k8sPod.Name,
+		node:        k8sPod.Spec.NodeName,
 		ip:          k8sPod.Status.PodIP,
 		serviceName: k8sPod.Labels["app"],
 	}

--- a/service.go
+++ b/service.go
@@ -18,12 +18,15 @@ type k8sHealthcheckService struct {
 	k8sClient   kubernetes.Interface
 	httpClient  *http.Client
 	deployments deploymentsMap
+	services    servicesMap
 }
 
 type healthcheckService interface {
 	getCategories() (map[string]category, error)
 	updateCategory(string, bool) error
-	getServicesByNames([]string) []service
+	getServiceByName(serviceName string) (service, error)
+	getServicesMapByNames([]string) map[string]service
+	isServicePresent(string) bool
 	getPodsForService(string) ([]pod, error)
 	getPodByName(string) (pod, error)
 	checkServiceHealth(service) (string, error)
@@ -38,11 +41,85 @@ type healthcheckService interface {
 }
 
 const (
-	defaultRefreshRate       = 60
-	defaultSeverity          = uint8(2)
+	defaultRefreshRate = 60
+	defaultSeverity = uint8(2)
 	ackMessagesConfigMapName = "healthcheck.ack.messages"
-	defaultAppPort           = int32(8080)
+	ackMessagesConfigMapLabelSelector = "healthcheck-acknowledgements-for=aggregate-healthcheck"
+	defaultAppPort = int32(8080)
 )
+
+func (hs *k8sHealthcheckService) updateAcksForServices(acksMap map[string]string) {
+	hs.services.Lock()
+	for serviceName, service := range hs.services.m {
+		if ackMsg, ok := acksMap[serviceName]; ok {
+			service.ack = ackMsg
+		} else {
+			service.ack = ""
+		}
+		hs.services.m[serviceName] = service
+	}
+	hs.services.Unlock()
+}
+
+func (hs *k8sHealthcheckService) watchAcks() {
+	watcher, err := hs.k8sClient.CoreV1().ConfigMaps("default").Watch(v1.ListOptions{LabelSelector: ackMessagesConfigMapLabelSelector})
+
+	if err != nil {
+		errorLogger.Printf("Error while starting to watch acks configMap with label selector: %s. Error was: %s", ackMessagesConfigMapLabelSelector, err.Error())
+	}
+
+	infoLogger.Print("Started watching services")
+	resultChannel := watcher.ResultChan()
+	for msg := range resultChannel {
+		switch msg.Type {
+		case watch.Added, watch.Modified:
+			k8sConfigMap := msg.Object.(*v1.ConfigMap)
+			hs.updateAcksForServices(k8sConfigMap.Data)
+			infoLogger.Printf("Acks configMap has been updated: %s", k8sConfigMap.Data)
+		case watch.Deleted:
+			errorLogger.Print("Acks configMap has been deleted. From now on the acks will no longer be available.")
+		default:
+			errorLogger.Print("Error received on watch acks configMap. Channel may be full")
+		}
+	}
+
+	infoLogger.Print("Acks configMap watching terminated. Reconnecting...")
+	hs.watchAcks()
+}
+
+func (hs *k8sHealthcheckService) watchServices() {
+	watcher, err := hs.k8sClient.CoreV1().Services("default").Watch(v1.ListOptions{LabelSelector: "hasHealthcheck=true"})
+	if err != nil {
+		errorLogger.Printf("Error while starting to watch services: %s", err.Error())
+	}
+
+	infoLogger.Print("Started watching services")
+	resultChannel := watcher.ResultChan()
+	for msg := range resultChannel {
+		switch msg.Type {
+		case watch.Added, watch.Modified:
+			k8sService := msg.Object.(*v1.Service)
+			service := populateService(k8sService)
+
+			hs.services.Lock()
+			hs.services.m[service.name] = service
+			hs.services.Unlock()
+
+			infoLogger.Printf("Service with name %s added or updated.", service.name)
+		case watch.Deleted:
+			k8sService := msg.Object.(*v1.Service)
+			hs.services.Lock()
+			delete(hs.services.m, k8sService.Name)
+			hs.services.Unlock()
+			infoLogger.Printf("Service with name %s has been removed", k8sService.Name)
+		default:
+			errorLogger.Print("Error received on watch services. Channel may be full")
+		}
+	}
+
+	infoLogger.Print("Services watching terminated. Reconnecting...")
+	hs.watchServices()
+}
 
 func (hs *k8sHealthcheckService) watchDeployments() {
 	watcher, err := hs.k8sClient.ExtensionsV1beta1().Deployments("default").Watch(v1.ListOptions{})
@@ -79,7 +156,7 @@ func (hs *k8sHealthcheckService) watchDeployments() {
 		}
 	}
 
-	errorLogger.Print("Deployments watching terminated. Reconnecting...")
+	infoLogger.Print("Deployments watching terminated. Reconnecting...")
 	hs.watchDeployments()
 }
 
@@ -106,14 +183,18 @@ func initializeHealthCheckService() *k8sHealthcheckService {
 	}
 
 	deployments := make(map[string]deployment)
+	services := make(map[string]service)
 
 	k8sService := &k8sHealthcheckService{
 		httpClient:  httpClient,
 		k8sClient:   k8sClient,
 		deployments: deploymentsMap{m: deployments},
+		services: servicesMap{m:services},
 	}
 
 	go k8sService.watchDeployments()
+	go k8sService.watchServices()
+	go k8sService.watchAcks()
 
 	return k8sService
 }
@@ -195,26 +276,44 @@ func (hs *k8sHealthcheckService) getPodByName(podName string) (pod, error) {
 	return p, nil
 }
 
-func (hs *k8sHealthcheckService) getServicesByNames(serviceNames []string) []service {
-	k8sServices, err := hs.k8sClient.CoreV1().Services("default").List(v1.ListOptions{LabelSelector: "hasHealthcheck=true"})
+func (hs *k8sHealthcheckService) isServicePresent(serviceName string) bool {
+	hs.services.RLock()
+	_, ok := hs.services.m[serviceName]
+	hs.services.RUnlock()
+	return ok
+}
 
-	if err != nil {
-		errorLogger.Printf("Failed to get the list of services from k8s cluster, error was %v", err.Error())
-		return []service{}
+func (hs *k8sHealthcheckService) getServiceByName(serviceName string) (service, error) {
+	hs.services.RLock()
+	defer hs.services.RUnlock()
+
+	if service, ok := hs.services.m[serviceName]; ok {
+		return service,nil
 	}
 
-	acks, err := getAcks(hs.k8sClient)
-
-	if err != nil {
-		warnLogger.Printf("Cannot get acks. There will be no acks at all. Problem was: %s", err.Error())
-	}
-
+	return service{}, fmt.Errorf("Cannot find service with name %s", serviceName)
+}
+func (hs *k8sHealthcheckService) getServicesMapByNames(serviceNames []string) map[string]service {
 	//if the list of service names is empty, it means that we are in the default category so we take all the services that have healthcheck
 	if len(serviceNames) == 0 {
-		return getAllServices(k8sServices.Items, acks)
+		hs.services.RLock()
+		defer hs.services.RUnlock()
+		//TODO: check if this map can be modified after it is returned.
+		return hs.services.m
 	}
 
-	return getServicesWithNames(k8sServices.Items, serviceNames, acks)
+	services := make(map[string]service)
+	hs.services.RLock()
+	for _, serviceName := range serviceNames {
+		if service, ok := hs.services.m[serviceName]; ok {
+			services[serviceName] = service
+		} else {
+			errorLogger.Printf("Service with name [%s] not found.", serviceName)
+		}
+	}
+
+	hs.services.RUnlock()
+	return services
 }
 
 func (hs *k8sHealthcheckService) getPodsForService(serviceName string) ([]pod, error) {
@@ -289,44 +388,7 @@ func populatePod(k8sPod v1.Pod) pod {
 	}
 }
 
-func getServiceByName(k8sServices []v1.Service, serviceName string) (v1.Service, error) {
-	for _, k8sService := range k8sServices {
-		if k8sService.Name == serviceName {
-			return k8sService, nil
-		}
-	}
-
-	return v1.Service{}, fmt.Errorf("Cannot find k8sService with name %s", serviceName)
-}
-
-func getServicesWithNames(k8sServices []v1.Service, serviceNames []string, acks map[string]string) []service {
-	services := []service{}
-
-	for _, serviceName := range serviceNames {
-		k8sService, err := getServiceByName(k8sServices, serviceName)
-		if err != nil {
-			errorLogger.Printf("Service with name [%s] cannot be found in k8s services. Error was: %v", serviceName, err)
-		} else {
-			s := populateService(k8sService, acks)
-			services = append(services, s)
-		}
-	}
-
-	return services
-}
-
-func getAllServices(k8sServices []v1.Service, acks map[string]string) []service {
-	infoLogger.Print("Using category default, retrieving all services.")
-	services := []service{}
-	for _, k8sService := range k8sServices {
-		s := populateService(k8sService, acks)
-		services = append(services, s)
-	}
-
-	return services
-}
-
-func populateService(k8sService v1.Service, acks map[string]string) service {
+func populateService(k8sService *v1.Service) service {
 	//services are resilient by default.
 	isResilient := true
 	isDaemon := false
@@ -348,13 +410,13 @@ func populateService(k8sService v1.Service, acks map[string]string) service {
 
 	return service{
 		name:        serviceName,
-		ack:         acks[k8sService.Name],
 		appPort:     getAppPortForService(k8sService),
 		isDaemon:    isDaemon,
 		isResilient: isResilient,
 	}
 }
-func getAppPortForService(k8sService v1.Service) int32 {
+
+func getAppPortForService(k8sService *v1.Service) int32 {
 	servicePorts := k8sService.Spec.Ports
 	for _, port := range servicePorts {
 		if port.Name == "app" {
@@ -363,16 +425,6 @@ func getAppPortForService(k8sService v1.Service) int32 {
 	}
 
 	return defaultAppPort
-}
-
-func getAcks(k8sClient kubernetes.Interface) (map[string]string, error) {
-	k8sAckConfigMap, err := getAcksConfigMap(k8sClient)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return k8sAckConfigMap.Data, nil
 }
 
 func getAcksConfigMap(k8sClient kubernetes.Interface) (v1.ConfigMap, error) {

--- a/service.go
+++ b/service.go
@@ -41,11 +41,11 @@ type healthcheckService interface {
 }
 
 const (
-	defaultRefreshRate = 60
-	defaultSeverity = uint8(2)
-	ackMessagesConfigMapName = "healthcheck.ack.messages"
+	defaultRefreshRate                = 60
+	defaultSeverity                   = uint8(2)
+	ackMessagesConfigMapName          = "healthcheck.ack.messages"
 	ackMessagesConfigMapLabelSelector = "healthcheck-acknowledgements-for=aggregate-healthcheck"
-	defaultAppPort = int32(8080)
+	defaultAppPort                    = int32(8080)
 )
 
 func (hs *k8sHealthcheckService) updateAcksForServices(acksMap map[string]string) {
@@ -189,7 +189,7 @@ func initializeHealthCheckService() *k8sHealthcheckService {
 		httpClient:  httpClient,
 		k8sClient:   k8sClient,
 		deployments: deploymentsMap{m: deployments},
-		services: servicesMap{m:services},
+		services:    servicesMap{m: services},
 	}
 
 	go k8sService.watchDeployments()

--- a/service.go
+++ b/service.go
@@ -51,6 +51,7 @@ func (hs *k8sHealthcheckService) watchDeployments() {
 		errorLogger.Printf("Error while starting to watch deployments: %s", err.Error())
 	}
 
+	infoLogger.Print("Started watching deployments")
 	resultChannel := watcher.ResultChan()
 	for msg := range resultChannel {
 		switch msg.Type {
@@ -74,9 +75,12 @@ func (hs *k8sHealthcheckService) watchDeployments() {
 			hs.deployments.Unlock()
 			infoLogger.Printf("Deployment %s has been removed", k8sDeployment.Name)
 		default:
-			errorLogger.Print("Error received on watch deployments. Channel may be full ")
+			errorLogger.Print("Error received on watch deployments. Channel may be full")
 		}
 	}
+
+	errorLogger.Print("Deployments watching terminated. Reconnecting...")
+	hs.watchDeployments()
 }
 
 func initializeHealthCheckService() *k8sHealthcheckService {

--- a/service.go
+++ b/service.go
@@ -360,7 +360,7 @@ func populateCategory(k8sCatData map[string]string) category {
 
 	isEnabled, err := strconv.ParseBool(k8sCatData["category.enabled"])
 	if err != nil {
-		infoLogger.Printf("isEnabled flag is not set for category with name for category with name [%s]. Using default value of true.", categoryName)
+		infoLogger.Printf("isEnabled flag is not set for category with name [%s]. Using default value of true.", categoryName)
 		isEnabled = true
 	}
 
@@ -371,9 +371,10 @@ func populateCategory(k8sCatData map[string]string) category {
 	}
 
 	refreshRatePeriod := time.Duration(refreshRateSeconds * int64(time.Second))
+	categories := strings.Replace(k8sCatData["category.services"], " ", "", -1)
 	return category{
 		name:          categoryName,
-		services:      strings.Split(k8sCatData["category.services"], ","),
+		services:      strings.Split(categories, ","),
 		refreshPeriod: refreshRatePeriod,
 		isSticky:      isSticky,
 		isEnabled:     isEnabled,

--- a/service.go
+++ b/service.go
@@ -137,16 +137,12 @@ func (hs *k8sHealthcheckService) addAck(serviceName string, ackMessage string) e
 }
 
 func (hs *k8sHealthcheckService) getPodByName(podName string) (pod, error) {
-	k8sPods, err := hs.k8sClient.CoreV1().Pods("default").List(v1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", podName)})
+	k8sPod, err := hs.k8sClient.CoreV1().Pods("default").Get(podName)
 	if err != nil {
 		return pod{}, fmt.Errorf("Failed to get the pod with name %s from k8s cluster, error was %v", podName, err.Error())
 	}
 
-	if len(k8sPods.Items) == 0 {
-		return pod{}, fmt.Errorf("Pod with name %s was not found in cluster, error was %v", podName, err.Error())
-	}
-
-	p := populatePod(k8sPods.Items[0])
+	p := populatePod(*k8sPod)
 	return p, nil
 }
 
@@ -331,15 +327,11 @@ func getAcks(k8sClient kubernetes.Interface) (map[string]string, error) {
 }
 
 func getAcksConfigMap(k8sClient kubernetes.Interface) (v1.ConfigMap, error) {
-	k8sAckConfigMaps, err := k8sClient.CoreV1().ConfigMaps("default").List(v1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", ackMessagesConfigMapName)})
+	k8sAckConfigMap, err := k8sClient.CoreV1().ConfigMaps("default").Get(ackMessagesConfigMapName)
 
 	if err != nil {
-		return v1.ConfigMap{}, fmt.Errorf("Cannot get configMap with name: %s from k8s cluster. Error was: %s", ackMessagesConfigMapName, err.Error())
+		return v1.ConfigMap{}, fmt.Errorf("Cannot fin configMap with name: %s. Error was: %s", ackMessagesConfigMapName, err.Error())
 	}
 
-	if len(k8sAckConfigMaps.Items) == 0 {
-		return v1.ConfigMap{}, fmt.Errorf("Cannot find configMap with name: %s", ackMessagesConfigMapName)
-	}
-
-	return k8sAckConfigMaps.Items[0], nil
+	return *k8sAckConfigMap, nil
 }

--- a/service_test.go
+++ b/service_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"os"
 )
 
 type MockWebClient struct{}
@@ -16,12 +17,12 @@ type mockTransport struct {
 }
 
 const (
-	validIP                             = "1.0.0.0"
-	validK8sServiceName                 = "validServiceName"
-	validK8sServiceNameWithAck          = "validK8sServiceNameWithAck"
-	nonExistingK8sServiceName           = "vnonExistingServiceName"
-	validSeverity                       = uint8(1)
-	ackMsg                              = "ack-msg"
+	validIP = "1.0.0.0"
+	validK8sServiceName = "validServiceName"
+	validK8sServiceNameWithAck = "validK8sServiceNameWithAck"
+	nonExistingK8sServiceName = "vnonExistingServiceName"
+	validSeverity = uint8(1)
+	ackMsg = "ack-msg"
 	validFailingHealthCheckResponseBody = `{
   "schemaVersion": 1,
   "name": "CMSNotifierApplication",
@@ -163,6 +164,7 @@ func TestCheckPodHealthFailingChecks(t *testing.T) {
 }
 
 func TestCheckPodHealthWithInvalidUrl(t *testing.T) {
+	initLogs(os.Stdout, os.Stdout, os.Stderr)
 	service := initializeMockService(nil)
 	err := service.checkPodHealth(pod{name: "test", ip: "%s"}, 8080)
 	assert.NotNil(t, err)

--- a/service_test.go
+++ b/service_test.go
@@ -16,12 +16,12 @@ type mockTransport struct {
 }
 
 const (
-	validIP = "1.0.0.0"
-	validK8sServiceName = "validServiceName"
-	validK8sServiceNameWithAck = "validK8sServiceNameWithAck"
-	nonExistingK8sServiceName ="vnonExistingServiceName"
-	validSeverity = uint8(1)
-	ackMsg = "ack-msg"
+	validIP                             = "1.0.0.0"
+	validK8sServiceName                 = "validServiceName"
+	validK8sServiceNameWithAck          = "validK8sServiceNameWithAck"
+	nonExistingK8sServiceName           = "vnonExistingServiceName"
+	validSeverity                       = uint8(1)
+	ackMsg                              = "ack-msg"
 	validFailingHealthCheckResponseBody = `{
   "schemaVersion": 1,
   "name": "CMSNotifierApplication",
@@ -71,15 +71,15 @@ const (
 func initializeMockServiceWithK8sServices() *k8sHealthcheckService {
 	services := make(map[string]service)
 	services[validK8sServiceName] = service{
-		name:validServiceName,
+		name: validServiceName,
 	}
 	services[validK8sServiceNameWithAck] = service{
-		name:validK8sServiceNameWithAck,
-		ack:"test",
+		name: validK8sServiceNameWithAck,
+		ack:  "test",
 	}
 	return &k8sHealthcheckService{
 		services: servicesMap{
-			m:services,
+			m: services,
 		},
 	}
 }
@@ -87,12 +87,12 @@ func initializeMockServiceWithK8sServices() *k8sHealthcheckService {
 func initializeMockServiceWithDeployments() *k8sHealthcheckService {
 	deployments := make(map[string]deployment)
 	deployments[validK8sServiceName] = deployment{
-		numberOfUnavailableReplicas:0,
-		numberOfAvailableReplicas:2,
+		numberOfUnavailableReplicas: 0,
+		numberOfAvailableReplicas:   2,
 	}
 	return &k8sHealthcheckService{
 		deployments: deploymentsMap{
-			m:deployments,
+			m: deployments,
 		},
 	}
 }
@@ -226,22 +226,22 @@ func TestCheckServiceHealthByResiliencyHappyFlow(t *testing.T) {
 func TestCheckServiceHealthWithDeploymentHappyFlow(t *testing.T) {
 	k8sHcService := initializeMockServiceWithDeployments()
 	s := service{
-		name:validK8sServiceName,
+		name:        validK8sServiceName,
 		isResilient: false,
 	}
 
-	_,err := k8sHcService.checkServiceHealth(s)
+	_, err := k8sHcService.checkServiceHealth(s)
 	assert.Nil(t, err)
 }
 
 func TestCheckServiceHealthWithDeploymentNonExistingServiceName(t *testing.T) {
 	k8sHcService := initializeMockServiceWithDeployments()
 	s := service{
-		name:nonExistingK8sServiceName,
+		name:        nonExistingK8sServiceName,
 		isResilient: false,
 	}
 
-	_,err := k8sHcService.checkServiceHealth(s)
+	_, err := k8sHcService.checkServiceHealth(s)
 	assert.NotNil(t, err)
 }
 
@@ -251,7 +251,6 @@ func TestUpdateAcksForServicesEmptyAckList(t *testing.T) {
 	acks[validK8sServiceName] = ackMsg
 	hcService.updateAcksForServices(acks)
 
-	assert.Equal(t, hcService.services.m[validK8sServiceNameWithAck].ack,"")
-	assert.Equal(t, hcService.services.m[validK8sServiceName].ack,ackMsg)
+	assert.Equal(t, hcService.services.m[validK8sServiceNameWithAck].ack, "")
+	assert.Equal(t, hcService.services.m[validK8sServiceName].ack, ackMsg)
 }
-

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -18,7 +18,9 @@
 			"checksumSHA1": "FUhczVSvt/VQAlWfzATo1YLez2E=",
 			"path": "github.com/Financial-Times/go-fthealth/v1a",
 			"revision": "f9074331b3ab48bca0e6d0afc211a673d88ac925",
-			"revisionTime": "2016-06-16T09:04:59Z"
+			"revisionTime": "2016-06-16T09:04:59Z",
+			"version": "0.1.0",
+			"versionExact": "0.1.0"
 		},
 		{
 			"checksumSHA1": "9Ob5JNGzi/pGXYMuHclig69IHPk=",
@@ -182,10 +184,18 @@
 			"revisionTime": "2016-11-22T19:10:42Z"
 		},
 		{
-			"checksumSHA1": "zmCk+lgIeiOf0Ng9aFP9aFy8ksE=",
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
+			"path": "github.com/gorilla/context",
+			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
+			"revisionTime": "2016-08-17T18:46:32Z"
+		},
+		{
+			"checksumSHA1": "F5dR3/i70EhSIMZfeIV+H8/PtvM=",
 			"path": "github.com/gorilla/mux",
-			"revision": "599cba5e7b6137d46ddf58fb1765f5d928e69604",
-			"revisionTime": "2017-02-28T22:43:54Z"
+			"revision": "392c28fe23e1c45ddba891b0320b3b5df220beea",
+			"revisionTime": "2017-01-18T13:43:44Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
 		},
 		{
 			"checksumSHA1": "pYoO37aSFZl2uJAXpePBDnGItZc=",
@@ -250,20 +260,26 @@
 		{
 			"checksumSHA1": "/kKwYqD04AkkDZFQhGwklKw3RFA=",
 			"path": "github.com/stretchr/testify",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
 		},
 		{
 			"checksumSHA1": "fg3TzS9/QK3wZbzei3Z6O8XPLHg=",
 			"path": "github.com/stretchr/testify/http",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
 		},
 		{
-			"checksumSHA1": "WGwMB6WljaeGKzuNCX5M4E8LADE=",
+			"checksumSHA1": "Je6cJkYWj2SoaHDMGpE00BGi9sw=",
 			"path": "github.com/stretchr/testify/mock",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
 		},
 		{
 			"checksumSHA1": "MWqyOvDMkW+XYe2RJ5mplvut+aE=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -266,6 +266,14 @@
 			"versionExact": "v1.1.4"
 		},
 		{
+			"checksumSHA1": "q1qqfgDOGwfEuMlbHWNjYf09ACM=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
+		},
+		{
 			"checksumSHA1": "fg3TzS9/QK3wZbzei3Z6O8XPLHg=",
 			"path": "github.com/stretchr/testify/http",
 			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",


### PR DESCRIPTION
Changes in this PR:
 - added watchers for deployments, services and acks map
 - fixed severities on reload from cache
 - added functionality to clear services that don't exist anymore from cache
 - fixed functionality to disable a sticky category when a service is unhealthy
 - added node name to individual service healthcheck for global services (i.e. system-healthcheck)