### PR TITLE
Take into consideration category refresh period settings

### DIFF
--- a/cachingController.go
+++ b/cachingController.go
@@ -54,7 +54,7 @@ func (c *healthCheckController) updateCachedHealth(services map[string]service, 
 			refreshPeriod := findShortestPeriod(categories)
 			categories, err := c.healthCheckService.getCategories()
 			if err != nil {
-				warnLogger.Printf("Cannot read categories: [%v]\n Using minimum refresh period for service [%s]\n", err, service.name)
+				warnLogger.Printf("Cannot read categories: [%v]\n Using minimum refresh period for service [%s]", err, service.name)
 			} else {
 				for _, category := range categories {
 					if isStringInSlice(service.name, category.services) {

--- a/cachingController.go
+++ b/cachingController.go
@@ -52,6 +52,18 @@ func (c *healthCheckController) updateCachedHealth(services map[string]service, 
 			newMService := newMeasuredService(service)
 			c.measuredServices[service.name] = newMService
 			refreshPeriod := findShortestPeriod(categories)
+			categories, err := c.healthCheckService.getCategories()
+			if err != nil {
+				warnLogger.Printf("Cannot read categories: [%v]\n Using minimum refresh period for service [%s]\n", err, service.name)
+			} else {
+				for _, category := range categories {
+					if isStringInSlice(service.name, category.services) {
+						refreshPeriod = category.refreshPeriod
+						break
+					}
+				}
+			}
+			infoLogger.Printf("Scheduling check for service [%s] with refresh period [%v].\n", service.name, refreshPeriod)
 			go c.scheduleCheck(newMService, refreshPeriod, time.NewTimer(0))
 		}
 	}

--- a/controller_test.go
+++ b/controller_test.go
@@ -222,6 +222,7 @@ func TestRemoveAckServiceErr(t *testing.T) {
 }
 
 func TestRemoveAckHappyFlow(t *testing.T) {
+	initLogs(os.Stdout, os.Stdout, os.Stderr)
 	controller := initializeMockController("test", nil)
 	err := controller.removeAck(validService)
 	assert.Nil(t, err)


### PR DESCRIPTION
- when scheduling checks, use the refresh period of the category the service is part of
- the flow I changed  reached when we ask for the health of an app for the first time, and usually that call is without a category, so the default category is used as a param for the method I changed
- I tried to write some tests but because of the nature of the flow,  I couldn't figure out how to write an automated test for it
