### PR TITLE
Prometheus metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "0.4.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -139,6 +147,14 @@
   version = "v1.1.5"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -177,6 +193,50 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:63b68062b8968092eb86bedc4e68894bd096ea6b24920faca8b9dcf451f54bb5"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8c49953a1414305f2ff5465147ee576dd705487c35b15918fcd4efdc0cb7a290"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
+  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
   digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
@@ -451,6 +511,7 @@
     "github.com/Financial-Times/go-fthealth/v1_1",
     "github.com/gorilla/mux",
     "github.com/jawher/mow.cli",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -195,15 +195,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
+  digest = "1:f5145508934af40ee3442fa058a0cd4a1696ca8f9f3d8c3fdb4d7fb75c858cd8"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
+    "prometheus/internal",
     "prometheus/promhttp",
   ]
   pruneopts = "UT"
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  revision = "7858729281ec582767b20e0d696b6041d995d5e0"
 
 [[projects]]
   branch = "master"
@@ -252,7 +252,7 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "182538f80094b6a8efaade63a8fd8e0d9d5843dd"
+  revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
 
 [[projects]]
   branch = "master"
@@ -266,18 +266,18 @@
     "idna",
   ]
   pruneopts = "UT"
-  revision = "8a410e7b638dca158bf9e766925842f6651ff828"
+  revision = "161cd47e91fd58ac17490ef4d742dc98bb4cf60e"
 
 [[projects]]
   branch = "master"
-  digest = "1:629034aef6b53eb8ea737e6d82cb5402907e2757fbab5ddf5e74c08b4c6473af"
+  digest = "1:374fc90fcb026e9a367e3fad29e988e5dd944b68ca3f24a184d77abc5307dda4"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "2b024373dcd9800f0cae693839fac6ede8d64a8c"
+  revision = "d0be0721c37eeb5299f245a996a483160fc36940"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -511,6 +511,7 @@
     "github.com/Financial-Times/go-fthealth/v1_1",
     "github.com/gorilla/mux",
     "github.com/jawher/mow.cli",
+    "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/core/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,7 +59,7 @@
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "=0.8.0"
+  revision = "7858729281ec582767b20e0d696b6041d995d5e0"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,6 +57,10 @@
   name = "k8s.io/kube-openapi"
   revision = "91cfa479c814065e420cee7ed227db0f63a5854e"
 
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "=0.8.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
+++ b/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ .Values.service.name }}
 spec:
   endpoints:
-    port: 8080
-    path: "/metrics"
+    - port: 8080
+    - path: "/metrics"
   selector:
     matchLabels:
       app: {{ .Values.service.name }}

--- a/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
+++ b/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.service.name }}
 spec:
   endpoints:
-    - port: 8080
+    - port: "8080"
     - path: "/metrics"
   selector:
     matchLabels:

--- a/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
+++ b/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
@@ -1,13 +1,15 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  labels:
+    component: {{ .Values.service.name }}
+    prometheus: {{ .Values.metrics.prometheusInstance }}
   name: {{ .Values.service.name }}
-  label:
-    prometheus: monitoring-metrics
 spec:
   endpoints:
-    - port: "8080"
-    - path: "/metrics"
+  - interval: {{ .Values.metrics.interval }}
+    path: {{ .Values.metrics.path }}
+  jobLabel: component
   selector:
     matchLabels:
       app: {{ .Values.service.name }}

--- a/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
+++ b/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
@@ -2,6 +2,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.service.name }}
+  label:
+    prometheus: monitoring-metrics
 spec:
   endpoints:
     - port: "8080"

--- a/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
+++ b/helm/upp-aggregate-healthcheck/templates/service-monitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.service.name }}
+spec:
+  endpoints:
+    port: 8080
+    path: "/metrics"
+  selector:
+    matchLabels:
+      app: {{ .Values.service.name }}

--- a/helm/upp-aggregate-healthcheck/values.yaml
+++ b/helm/upp-aggregate-healthcheck/values.yaml
@@ -27,4 +27,11 @@ categories:
     data:
       category.name: default
       category.refreshrate: "60"
-
+metrics:
+  # where we expose the metrics for prometheus
+  path: /metrics
+  # how often prometheus will call the metrics path
+  interval: 60s
+  # the name of the prometheus instance, as defined in
+  # content-k8s-prometheus\helm\content-k8s-prometheus\app-configs\monitoring-metrics_{env}.yaml
+  prometheusInstance: monitoring-metrics

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -63,6 +64,14 @@ func main() {
 		graphiteFeeder := newGraphiteFeeder(*graphiteURL, *environment, controller)
 		go graphiteFeeder.feed()
 
+		pilotLight := prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "upp",
+			Subsystem: "health",
+			Name:      "pilot-light",
+			Help:      "Pilot light for the service monitoring UPP service health",
+		})
+		prometheus.MustRegister(pilotLight)
+		pilotLight.Set(1)
 		listen(handler, *pathPrefix)
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const logPattern = log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile | log.LUTC
@@ -75,6 +76,7 @@ func listen(httpHandler *httpHandler, pathPrefix string) {
 	r := mux.NewRouter()
 	r.HandleFunc("/__gtg", httpHandler.handleGoodToGo)
 	s := r.PathPrefix(pathPrefix).Subrouter()
+	r.Handle("/metrics", promhttp.Handler())
 	s.HandleFunc("/add-ack", httpHandler.handleAddAck).Methods("POST")
 	s.HandleFunc("/enable-category", httpHandler.handleEnableCategory)
 	s.HandleFunc("/disable-category", httpHandler.handleDisableCategory)

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -64,18 +63,9 @@ func main() {
 		graphiteFeeder := newGraphiteFeeder(*graphiteURL, *environment, controller)
 		go graphiteFeeder.feed()
 
-		pilotLight := prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "upp",
-				Subsystem: "health",
-				Name:      "pilotlight",
-				Help:      "Pilot light for the service monitoring UPP service health",
-			},
-			[]string{
-				"environment",
-			})
-		prometheus.MustRegister(pilotLight)
-		pilotLight.With(prometheus.Labels{"environment": *environment}).Set(1)
+		prometheusFeeder := newPrometheusFeeder(*environment, controller)
+		go prometheusFeeder.feed()
+
 		listen(handler, *pathPrefix)
 	}
 

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 		pilotLight := prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "upp",
 			Subsystem: "health",
-			Name:      "pilot-light",
+			Name:      "pilotlight",
 			Help:      "Pilot light for the service monitoring UPP service health",
 		})
 		prometheus.MustRegister(pilotLight)

--- a/main.go
+++ b/main.go
@@ -64,14 +64,18 @@ func main() {
 		graphiteFeeder := newGraphiteFeeder(*graphiteURL, *environment, controller)
 		go graphiteFeeder.feed()
 
-		pilotLight := prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "upp",
-			Subsystem: "health",
-			Name:      "pilotlight",
-			Help:      "Pilot light for the service monitoring UPP service health",
-		})
+		pilotLight := prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "upp",
+				Subsystem: "health",
+				Name:      "pilotlight",
+				Help:      "Pilot light for the service monitoring UPP service health",
+			},
+			[]string{
+				"environment",
+			})
 		prometheus.MustRegister(pilotLight)
-		pilotLight.Set(1)
+		pilotLight.With(prometheus.Labels{"environment": *environment}).Set(1)
 		listen(handler, *pathPrefix)
 	}
 

--- a/main.go
+++ b/main.go
@@ -78,8 +78,8 @@ func main() {
 func listen(httpHandler *httpHandler, pathPrefix string) {
 	r := mux.NewRouter()
 	r.HandleFunc("/__gtg", httpHandler.handleGoodToGo)
-	s := r.PathPrefix(pathPrefix).Subrouter()
 	r.Handle("/metrics", promhttp.Handler())
+	s := r.PathPrefix(pathPrefix).Subrouter()
 	s.HandleFunc("/add-ack", httpHandler.handleAddAck).Methods("POST")
 	s.HandleFunc("/enable-category", httpHandler.handleEnableCategory)
 	s.HandleFunc("/disable-category", httpHandler.handleDisableCategory)

--- a/model.go
+++ b/model.go
@@ -41,4 +41,5 @@ type measuredService struct {
 	service         service
 	cachedHealth    *cachedHealth
 	bufferedHealths *bufferedHealths
+	bufferedMetrics *bufferedHealths
 }

--- a/prometheusFeeder.go
+++ b/prometheusFeeder.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type prometheusFeeder struct {
+	environment string
+	ticker      *time.Ticker
+	controller  controller
+}
+
+func newPrometheusFeeder(environment string, controller controller) *prometheusFeeder {
+	ticker := time.NewTicker(60 * time.Second)
+	return &prometheusFeeder{
+		environment: environment,
+		ticker:      ticker,
+		controller:  controller,
+	}
+}
+
+func (g prometheusFeeder) feed() {
+	setPilotLight(g.environment)
+	serviceStatus := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "upp",
+			Subsystem: "health",
+			Name:      "servicestatus",
+			Help:      "Status of the service: 0 - healthy; 1 - unhealthy",
+		},
+		[]string{
+			"environment",
+			"service",
+		})
+	prometheus.MustRegister(serviceStatus)
+	for range g.ticker.C {
+		for _, mService := range g.controller.getMeasuredServices() {
+			for {
+				select {
+				case checkResult := <-mService.bufferedHealths.buffer:
+					name := strings.Replace(checkResult.Name, ".", "-", -1)
+					checkStatus := inverseBoolToInt(checkResult.Ok)
+					serviceStatus.With(prometheus.Labels{"environment": g.environment, "service": name}).Set(float64(checkStatus))
+				}
+			}
+		}
+	}
+}
+
+func setPilotLight(environment string) {
+	pilotLight := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "upp",
+			Subsystem: "health",
+			Name:      "pilotlight",
+			Help:      "Pilot light for the service monitoring UPP service health",
+		},
+		[]string{
+			"environment",
+		})
+	prometheus.MustRegister(pilotLight)
+	pilotLight.With(prometheus.Labels{"environment": environment}).Set(1)
+}

--- a/prometheusFeeder.go
+++ b/prometheusFeeder.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strconv"
 	"strings"
 	"time"
 
@@ -35,7 +34,6 @@ func (g prometheusFeeder) feed() {
 		[]string{
 			"environment",
 			"service",
-			"lastUpdate",
 		})
 	prometheus.MustRegister(serviceStatus)
 	for range g.ticker.C {
@@ -44,13 +42,7 @@ func (g prometheusFeeder) feed() {
 			case checkResult := <-mService.bufferedHealths.buffer:
 				name := strings.Replace(checkResult.Name, ".", "-", -1)
 				checkStatus := inverseBoolToInt(checkResult.Ok)
-				lastUpdate := strconv.FormatInt(checkResult.LastUpdated.Unix(), 10)
-				serviceStatus.With(
-					prometheus.Labels{
-						"environment": g.environment,
-						"service":     name,
-						"lastUpdate":  lastUpdate,
-					}).Set(float64(checkStatus))
+				serviceStatus.With(prometheus.Labels{"environment": g.environment, "service": name}).Set(float64(checkStatus))
 			default:
 				continue
 			}

--- a/prometheusFeeder.go
+++ b/prometheusFeeder.go
@@ -38,13 +38,13 @@ func (g prometheusFeeder) feed() {
 	prometheus.MustRegister(serviceStatus)
 	for range g.ticker.C {
 		for _, mService := range g.controller.getMeasuredServices() {
-			for {
-				select {
-				case checkResult := <-mService.bufferedHealths.buffer:
-					name := strings.Replace(checkResult.Name, ".", "-", -1)
-					checkStatus := inverseBoolToInt(checkResult.Ok)
-					serviceStatus.With(prometheus.Labels{"environment": g.environment, "service": name}).Set(float64(checkStatus))
-				}
+			select {
+			case checkResult := <-mService.bufferedHealths.buffer:
+				name := strings.Replace(checkResult.Name, ".", "-", -1)
+				checkStatus := inverseBoolToInt(checkResult.Ok)
+				serviceStatus.With(prometheus.Labels{"environment": g.environment, "service": name}).Set(float64(checkStatus))
+			default:
+				continue
 			}
 		}
 	}

--- a/prometheusFeeder.go
+++ b/prometheusFeeder.go
@@ -34,7 +34,7 @@ func (p prometheusFeeder) feed() {
 func (p prometheusFeeder) recordMetrics(serviceStatus *prom.GaugeVec) {
 	for _, service := range p.controller.getMeasuredServices() {
 		select {
-		case checkResult := <-service.bufferedHealths.buffer:
+		case checkResult := <-service.bufferedMetrics.buffer:
 			name := strings.Replace(checkResult.Name, ".", "-", -1)
 			checkStatus := inverseBoolToFloat64(checkResult.Ok)
 			serviceStatus.

--- a/prometheusFeeder_test.go
+++ b/prometheusFeeder_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+const ENV = "foobar"
+
+func TestNewPrometheusFeeder(t *testing.T) {
+	feeder := newPrometheusFeeder(ENV, &healthCheckController{})
+	assert.NotNil(t, feeder)
+	assert.Equal(t, ENV, feeder.environment, "Environment should be set correctly.")
+}
+
+func TestInitServiceStatusMetrics(t *testing.T) {
+	gauge := initServiceStatusMetrics()
+	assert.NotNil(t, gauge)
+	duplicateGauge := prom.NewGaugeVec(
+		prom.GaugeOpts{
+			Namespace: "upp",
+			Subsystem: "health",
+			Name:      "servicestatus",
+			Help:      "Status of the service: 0 - healthy; 1 - unhealthy",
+		},
+		[]string{
+			"environment",
+			"service",
+		})
+
+	err := prom.Register(duplicateGauge)
+	assert.NotNil(t, err, "Gauge should've been registered already.")
+	_, ok := err.(prom.AlreadyRegisteredError)
+	assert.True(t, ok, "Expecting an 'AlreadyRegisteredError'.")
+}
+func TestIgnitePilotLight(t *testing.T) {
+	ignitePilotLight(ENV)
+	duplicateGauge := prom.NewGaugeVec(
+		prom.GaugeOpts{
+			Namespace: "upp",
+			Subsystem: "health",
+			Name:      "pilotlight",
+			Help:      "Pilot light for the service monitoring UPP service health",
+		},
+		[]string{
+			"environment",
+		})
+
+	err := prom.Register(duplicateGauge)
+	assert.NotNil(t, err, "Gauge should've been registered already.")
+	_, ok := err.(prom.AlreadyRegisteredError)
+	assert.True(t, ok, "Expecting an 'AlreadyRegisteredError'.")
+}
+
+func TestInverseBoolToFloat64(t *testing.T) {
+	one := inverseBoolToFloat64(false)
+	assert.Equal(t, float64(1), one)
+
+	zero := inverseBoolToFloat64(true)
+	assert.Equal(t, float64(0), zero)
+}


### PR DESCRIPTION
- used the prometheus go client to generate service status and pilot light metrics, which Prometheus will read from the newly-exposed `/metrics` endpoint
- client version is pinned at current master tip, see why [here](https://github.com/prometheus/client_golang#important-note-about-releases-versioning-tagging-stability-and-your-favorite-go-dependency-management-tool)
- for simplicity, I have reproduced the metric feeding mechanism the graphite feeder uses
  - after we no longer need graphite, this solution can be simplified to just read the latest metric value instead of buffering
- the `ServiceMonitor` component tells Prometheus that it should scrape our `metrics` endpoint for metrics