### PR TITLE
Revert "Added readiness probe on /health to give it a chance to start…

### DIFF
--- a/helm/upp-aggregate-healthcheck/templates/deployment.yaml
+++ b/helm/upp-aggregate-healthcheck/templates/deployment.yaml
@@ -52,17 +52,7 @@ spec:
         livenessProbe: 
           tcpSocket: 
             port: 8080 
-          initialDelaySeconds: 30
-        readinessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /__health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 3
+          initialDelaySeconds: 30 
         resources: 
 {{ toYaml .Values.resources | indent 12 }}
 


### PR DESCRIPTION
… properly, it is bombarded with requests."

This reverts commit 40b6bcd, as it doesn't work properly with the current agg-hc code.