### PR TITLE
Stop checking annotations-mapper's health as it's being decommissioned

### DIFF
--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
@@ -150,7 +150,7 @@ categories:
         healthcheck-categories-for: aggregate-healthcheck
     data:
       category.name: annotations-read
-      category.services: annotations-mapper,annotations-rw-neo4j,upp-next-video-annotations-mapper,pac-annotations-mapper,system-healthcheck
+      category.services: annotations-rw-neo4j,upp-next-video-annotations-mapper,pac-annotations-mapper,system-healthcheck
       category.refreshrate: "60"
       category.issticky: "false"
   - kind: ConfigMap


### PR DESCRIPTION
# Description
## What

Remove `annotations-mapper` from `annotations-read` `category` in upp-aggregate-healthcheck_eks_delivery.yaml

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-2377)

## Note for the reviewers

Is this a minor release or a patch ? 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
