### PR TITLE
Remove synthetic-image-publication-monitor

### DIFF
--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
@@ -115,7 +115,7 @@ categories:
     immutable: false
     data:
       category.name: image-publish
-      category.services: cms-kafka-bridge-pub-pre-prod,cms-notifier,content-ingester,document-store-api,synthetic-image-publication-monitor,system-healthcheck
+      category.services: cms-kafka-bridge-pub-pre-prod,cms-notifier,content-ingester,document-store-api,system-healthcheck
       category.refreshrate: "60"
       category.issticky: "false"
   - kind: ConfigMap


### PR DESCRIPTION
# Description

## What

Remove `coco-synthetic-image-publication-monitor`

## Why

[UPPSF-2934](https://financialtimes.atlassian.net/browse/UPPSF-2934)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
