### PR TITLE
Removing wordpress mappers from aggregate healthcheck

### DIFF
--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
@@ -31,7 +31,7 @@ categories:
     immutable: false
     data:
       category.name: content-publish
-      category.services: upp-notifications-creator,notifications-push,cms-kafka-bridge-pub-pre-prod,cms-notifier,content-ingester,document-store-api,video-mapper,wordpress-article-mapper,wordpress-image-mapper
+      category.services: upp-notifications-creator,notifications-push,cms-kafka-bridge-pub-pre-prod,cms-notifier,content-ingester,document-store-api,video-mapper
       category.refreshrate: "60"
       category.issticky: "false"
   - kind: ConfigMap


### PR DESCRIPTION
# Description

## What

Part of wordpress mappers decomissioning

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3173

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
