### PR TITLE
Feature/uppsf 5570 remove draft flow from pac monitoring part

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ft-golang-ci: financial-times/golang-ci@1
+  ft-golang-ci: financial-times/golang-ci@2
 
 workflows:
   tests_and_docker:
@@ -13,8 +13,3 @@ workflows:
           name: build-docker-image
           requires:
             - build-and-test-project
-  snyk-scanning:
-    jobs:
-      - ft-golang-ci/scan:
-          name: scan-dependencies
-          context: cm-team-snyk

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Financial-Times/upp-aggregate-healthcheck
 
-go 1.22.0
+go 1.23
 
 require (
 	github.com/Financial-Times/go-fthealth v0.6.2

--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_pac.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_pac.yaml
@@ -31,9 +31,6 @@ categories:
       category.services: >- 
         annotations-publisher,
         draft-annotations-api,
-        draft-content-api,
-        draft-content-public-read,
-        draft-content-suggestions,
         generic-rw-aurora
       category.refreshrate: "60"
       category.issticky: "false"


### PR DESCRIPTION
# Description

## What

Decommission PAC draft flow - monitoring part.

## Why

[UPPSF-5569](https://financialtimes.atlassian.net/browse/UPPSF-5569)

## Anything, in particular, you'd like to highlight to reviewers

If these records are still in healthcheck for PAC, the Heimdall will fail the service status and Pingdom will failover the whole PAC cluster, when we scale down the services. So we need first to remove the healthchecks and only then to scale-down the services. 

Also updated the Go version and removed Snyk as tech hygiene.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-5569]: https://financialtimes.atlassian.net/browse/UPPSF-5569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ