### PR TITLE
Add draft-annotations-publisher to publish category 

### DIFF
--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_dev_eu.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_dev_eu.yaml
@@ -27,7 +27,7 @@ categories:
     immutable: false
     data:
       category.name: publish
-      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw
+      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw, draft-annotations-publisher
       category.refreshrate: "60"
       category.issticky: "true"
   - kind: ConfigMap

--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_prod_eu.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_prod_eu.yaml
@@ -27,7 +27,7 @@ categories:
     immutable: false
     data:
       category.name: publish
-      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw
+      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw, draft-annotations-publisher
       category.refreshrate: "60"
       category.issticky: "true"
   - kind: ConfigMap

--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_prod_us.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_prod_us.yaml
@@ -27,7 +27,7 @@ categories:
     immutable: false
     data:
       category.name: publish
-      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw
+      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw, draft-annotations-publisher
       category.refreshrate: "60"
       category.issticky: "false"
   - kind: ConfigMap

--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_staging_eu.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_staging_eu.yaml
@@ -27,7 +27,7 @@ categories:
     immutable: false
     data:
       category.name: publish
-      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw
+      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw, draft-annotations-publisher
       category.refreshrate: "60"
       category.issticky: "true"
   - kind: ConfigMap

--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_staging_us.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_publish_staging_us.yaml
@@ -27,7 +27,7 @@ categories:
     immutable: false
     data:
       category.name: publish
-      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw
+      category.services: cms-notifier, native-ingester-cms, cms-metadata-notifier, native-ingester-metadata, nativerw, draft-annotations-publisher
       category.refreshrate: "60"
       category.issticky: "false"
   - kind: ConfigMap


### PR DESCRIPTION
# Description

Add draft-annotations-publisher to the publish category on the publishing cluster

## What

With the switch of FT Pink Annotations to the new annotations flow we are adding  draft-annotations-publisher to the publish category of the publishing cluster to ensuure proper monitoring and failover.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-5694)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
