### PR TITLE
Adds cm-content-tree-api to categories, read and internalcontent-read

### DIFF
--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
@@ -81,6 +81,7 @@ categories:
         document-store-api,
         enriched-content-read-api,
         internal-content-api,
+        cm-content-tree-api,
         content-unroller,
         public-annotations-api,
         relations-api
@@ -119,6 +120,7 @@ categories:
         content-search-api-port,
         concept-search-api,
         internal-content-api,
+        cm-content-tree-api,
         enriched-content-read-api,
         content-public-read,
         document-store-api,


### PR DESCRIPTION
# Description

## What

This PR adds the newly created [cm-content-tree-api](https://github.com/Financial-Times/cm-content-tree-api) the categories **read** and **internalcontent-read**. 

It is deployed in dev and the checks can be found here.

[read](https://upp-k8s-dev-delivery-eu.upp.ft.com/__health?categories=read)
[internalcontent-read](https://upp-k8s-dev-delivery-eu.upp.ft.com/__health?categories=internalcontent-read)

## Why

JIRA --> https://financialtimes.atlassian.net/browse/UPPSF-5972

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
