### PR TITLE
Add cm-live-events-api to the read category

### DIFF
--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
@@ -124,6 +124,7 @@ categories:
         concept-search-api,
         internal-content-api,
         cm-content-tree-api,
+        cm-live-events-api,
         enriched-content-read-api,
         content-public-read,
         document-store-api,


### PR DESCRIPTION
# Description

## What

Add the `cm-live-events-api` to the `read` category for `delivery`.
Cross-check the service name: https://github.com/Financial-Times/cm-live-events-api/blob/1cd957e967083a8ab533851f4432444bba1bb211/helm/cm-live-events-api/app-configs/cm-live-events-api_eks_delivery_prod_eu.yaml#L4

Dev health check for category `read`
https://upp-k8s-dev-delivery-eu.upp.ft.com/__health?categories=read
## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-6094)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
