### PR TITLE
UPPSF-6089 use RWMutex to escape fatal error: concurrent map iteration and ...

### DIFF
--- a/cachingController.go
+++ b/cachingController.go
@@ -33,6 +33,7 @@ func (c *healthCheckController) collectChecksFromCachesFor(ctx context.Context, 
 	serviceNames := getServiceNamesFromCategories(categories)
 	services := c.healthCheckService.getServicesMapByNames(serviceNames)
 	servicesThatAreNotInCache := make(map[string]service)
+	c.healthCheckService.RLockServices()
 	for _, service := range services {
 		if mService, ok := c.measuredServices[service.name]; ok {
 			checkResult := <-mService.cachedHealth.toReadFromCache
@@ -41,6 +42,7 @@ func (c *healthCheckController) collectChecksFromCachesFor(ctx context.Context, 
 			servicesThatAreNotInCache[service.name] = service
 		}
 	}
+	c.healthCheckService.RUnlockServices()
 
 	if len(servicesThatAreNotInCache) != 0 {
 		notCachedChecks, err := c.runServiceChecksByServiceNames(ctx, servicesThatAreNotInCache, categories)

--- a/controller.go
+++ b/controller.go
@@ -301,7 +301,7 @@ func isStringInSlice(a string, list []string) bool {
 	return false
 }
 
-//used for sorting checks
+// used for sorting checks
 type byNameComparator []fthealth.CheckResult
 
 func (s byNameComparator) Less(i, j int) bool {

--- a/controller_test.go
+++ b/controller_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Financial-Times/go-logger"
 	"net/http"
 	"testing"
 	"time"
 
-	fthealth "github.com/Financial-Times/go-fthealth/v1_1"
-	"github.com/stretchr/testify/assert"
+	"github.com/Financial-Times/go-logger"
+
 	"strconv"
 	"strings"
+
+	fthealth "github.com/Financial-Times/go-fthealth/v1_1"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -52,6 +54,10 @@ type MockService struct {
 	getServiceByNameErr error
 	getDeploymentsErr   error
 }
+
+func (m *MockService) RLockServices() {}
+
+func (m *MockService) RUnlockServices() {}
 
 func (m *MockService) getCategories(_ context.Context) (map[string]category, error) {
 	categories := make(map[string]category)

--- a/service.go
+++ b/service.go
@@ -40,6 +40,8 @@ type healthcheckService interface {
 	addAck(context.Context, string, string) error
 	removeAck(context.Context, string) error
 	getHTTPClient() *http.Client
+	RLockServices()
+	RUnlockServices()
 }
 
 const (
@@ -52,6 +54,14 @@ const (
 	ackMessagesConfigMapLabelSelector = "healthcheck-acknowledgements-for=aggregate-healthcheck"
 	defaultAppPort                    = int32(8080)
 )
+
+func (hs *k8sHealthcheckService) RLockServices() {
+	hs.services.RLock()
+}
+
+func (hs *k8sHealthcheckService) RUnlockServices() {
+	hs.services.RUnlock()
+}
 
 func (hs *k8sHealthcheckService) updateAcksForServices(acksMap map[string]string) {
 	hs.services.Lock()


### PR DESCRIPTION
use RWMutex to escape fatal error: concurrent map iteration and map write, when we are reinitialising the map from watchServices() and a request is handled by the handler

# Description

In the middle of March we have detected several automatic failovers caused by panic in the upp-aggregate-healthcheck.
After investigation we have detected that there is a concurrency issue in re-create the map, while it is still in use and is filled with data in parallel.

## What

The proposed fix is to synchronize the map with the services in the healtcheck, so we cannot re-create it while the iteration over it is in process and we check the health of each and every service one by one. Only in between the checks we can refresh the service list. 

## Why

[UPPSF-6089](https://financialtimes.atlassian.net/browse/UPPSF-6089)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to. E.g.

_Would appreciate a second pair of eyes on the test_
_I am not quite sure how this bit works_
_Is there a better library for doing x_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-6089]: https://financialtimes.atlassian.net/browse/UPPSF-6089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ