### PR TITLE
Add reading-monitors category and add cm-read-availability-monitor in…

### DIFF
--- a/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
+++ b/helm/upp-aggregate-healthcheck/app-configs/upp-aggregate-healthcheck_eks_delivery.yaml
@@ -255,3 +255,16 @@ categories:
       category.services: concept-search-api
       category.refreshrate: "60"
       category.issticky: "false"
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: category.reading-monitors
+      labels:
+        healthcheck-categories-for: aggregate-healthcheck
+    immutable: false
+    data:
+      category.name: reading-monitors
+      category.services: >-
+        cm-read-availability-monitor
+      category.refreshrate: "60"
+      category.issticky: "false"


### PR DESCRIPTION
# Description

## What

Introducing new category to the delivery cluster `reading-monitors` and adding `cm-read-availability-monitor` service into it.

## Why

[UPPSF-6194](https://financialtimes.atlassian.net/browse/UPPSF-6194)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-6194]: https://financialtimes.atlassian.net/browse/UPPSF-6194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ